### PR TITLE
Update PluggableS3Transport.java

### DIFF
--- a/b2b-s3-plugin/src/com/axway/gps/PluggableS3Transport.java
+++ b/b2b-s3-plugin/src/com/axway/gps/PluggableS3Transport.java
@@ -293,7 +293,7 @@ public class PluggableS3Transport implements PluggableClient {
 
 			    File file = message.getData().toFile();
 				amazonS3.putObject(new PutObjectRequest(_bucket, ProductionFileName, file)
-						.withCannedAcl(CannedAccessControlList.PublicRead));
+						.withCannedAcl(CannedAccessControlList.Private));
 
 		    }
 


### PR DESCRIPTION
Update the ACL to upload the files in S3 using Private ACL instead of Public ACL. This change is required as PublicRead permission mandates the S3 bucket to be public which certain projects will not want considering the security.